### PR TITLE
Draft: TS types for custom input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "svelte-kbc",
-	"version": "0.0.7",
+	"version": "0.1.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "svelte-kbc",
-			"version": "0.0.7",
+			"version": "0.1.1",
 			"devDependencies": {
 				"@changesets/cli": "^2.25.0",
 				"@sveltejs/adapter-auto": "next",

--- a/src/lib/KeyboardControls.svelte
+++ b/src/lib/KeyboardControls.svelte
@@ -1,17 +1,31 @@
 <script lang="ts">
 	import { BROWSER } from 'esm-env';
 	import { setContext, getContext, onDestroy, tick } from 'svelte';
-	import { writable, } from 'svelte/store';
-	import type { KeyboardControl } from './models';
+	import { writable } from 'svelte/store';
+	import type { Controls, ControlsContext, KeyboardControl } from './models';
 
 	export let config: KeyboardControl[] = [];
 	export let eventProperty: keyof KeyboardEvent = 'key';
 	export let debug: boolean = false;
 
-	setContext<any>('threlte-keyboard-controls', {
+	type ObjectFromList<T extends ReadonlyArray<string>, V = string> = {
+		[K in T extends ReadonlyArray<infer U> ? U : never]: V;
+	};
+
+	const list = ['w', 'a', 's'] as const;
+
+	const actionNames = config.map((k) => k.name);
+
+	const obj: ObjectFromList<typeof list> = {
+		a: '',
+		s: '',
+		w: ''
+	};
+
+	setContext<ControlsContext>('threlte-keyboard-controls', {
 		controls: {}
 	});
-	let { controls } = getContext<any>('threlte-keyboard-controls');
+	let { controls } = getContext<ControlsContext>('threlte-keyboard-controls');
 
 	let keycodeToControlName: any = {};
 	let eventToControlName: any = {};
@@ -44,6 +58,8 @@
 			}
 			controls[control.name] = writable(false);
 		}
+
+		console.log(controls);
 	}
 
 	function updateKeyboardControls(controlName: string, status: boolean, event: any = null) {

--- a/src/lib/Testing_custom.svelte
+++ b/src/lib/Testing_custom.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { useKeyboardControls } from './hooks';
+	import type { KeyboardControl } from './models';
+
+	export let config: KeyboardControl[];
+
+	const customConfig = [
+		{ name: 'reload', keys: ['r'] },
+		{ name: 'scopeSwap', keys: ['t'] }
+	] as const;
+
+	const g = useKeyboardControls<typeof customConfig>();
+	const { reload, scopeSwap } = g;
+
+	let active: any = {
+		reload: false,
+		scopeSwap: false
+	};
+
+	$: active['reload'] = $reload;
+	$: active['scopeSwap'] = $scopeSwap;
+</script>
+
+<h2>wasdConfig Testing</h2>
+<div class="keys">
+	{#each config as control (control.name)}
+		<span class="key" style:background={active[control.name] ? '#3ebf77' : '#eeeeee'}>
+			{control.name}
+		</span>
+	{/each}
+</div>
+
+<style>
+	.keys {
+		display: flex;
+		justify-content: flex-start;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.key {
+		width: 3rem;
+		height: 3rem;
+		border-radius: 50%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+</style>

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,6 +1,15 @@
-import { getContext } from 'svelte'
+import { getContext } from 'svelte';
+import type {
+	Controls,
+	ControlsContext,
+	KeyboardControl,
+	UseKeyboardControls,
+	UseKeyboardControlsConfig
+} from './models';
+import type { Writable } from 'svelte/store';
 
-export const useKeyboardControls = () => {
-	const { controls } = getContext<any>('threlte-keyboard-controls');
-  return controls
+export function useKeyboardControls<T extends UseKeyboardControlsConfig>(): UseKeyboardControls<T> {
+	const { controls } = getContext<ControlsContext>('threlte-keyboard-controls');
+
+	return controls;
 }

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,11 +1,14 @@
-export type KeyConfig = string | string[];
-export type KbcEvent = 'click' | 'pointerdown' | 'pointerup' | 'touchstart' | 'touchend' | 'scroll'
+import { writable, type Writable } from 'svelte/store';
+import { wasdConfig } from './keyConfigs';
 
-export interface KeyboardControl {
-	name: string;
-	keys?: KeyConfig[];
-	events?: KbcEvent[];
-}
+export type KeyConfig = string | string[];
+export type KbcEvent = 'click' | 'pointerdown' | 'pointerup' | 'touchstart' | 'touchend' | 'scroll';
+
+export type KeyboardControl = {
+	readonly name: string;
+	readonly keys?: KeyConfig[];
+	readonly events?: KbcEvent[];
+};
 export interface WASDNameMap {
 	w?: string;
 	a?: string;
@@ -54,3 +57,17 @@ export interface NumericNameMap {
 	key8?: string;
 	key9?: string;
 }
+
+export type Controls = {
+	[key: string]: Writable<boolean | Event>;
+};
+
+export type UseKeyboardControlsConfig = readonly Pick<KeyboardControl, 'name'>[];
+
+export type ControlsContext = {
+	controls: Controls;
+};
+
+export type UseKeyboardControls<T extends UseKeyboardControlsConfig> = {
+	[E in T as E[number]['name']]: Writable<boolean | Event>;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import KeyboardControls from '$lib/KeyboardControls.svelte';
 	import { alphaConfig, numericConfig, wasdConfig } from '$lib/keyConfigs';
 	import TestingAlphaConfig from '$lib/Testing_alphaConfig.svelte';
+	import TestingCustom from '$lib/Testing_custom.svelte';
 	import Testing_Events from '$lib/Testing_Events.svelte';
 	import TestingNumericConfig from '$lib/Testing_numericConfig.svelte';
 	import TestingWasdConfig from '$lib/Testing_wasdConfig.svelte';
@@ -14,10 +15,14 @@
 		{ name: 'Pointer_Up', events: ['pointerup'] },
 		{ name: 'Touch_Start', events: ['touchstart'] },
 		{ name: 'Touch_End', events: ['touchend'] },
-		{ name: 'SCROLL', events: ['scroll'] },
+		{ name: 'SCROLL', events: ['scroll'] }
 		// { name: 'metaY', keys: ['y'] , preventDefault: true }
 	];
 
+	const customConfig = [
+		{ name: 'reload', keys: ['r'] },
+		{ name: 'scopeSwap', keys: ['t'] }
+	];
 </script>
 
 <main>
@@ -25,6 +30,9 @@
 	<pre>
   <code>npm i -D svelte-kbc</code>
 </pre>
+	<KeyboardControls config={customConfig}>
+		<TestingCustom config={customConfig} />
+	</KeyboardControls>
 	<KeyboardControls config={alphaConfig()}>
 		<TestingAlphaConfig config={alphaConfig()} />
 	</KeyboardControls>
@@ -46,5 +54,4 @@
 		min-height: 125vh;
 		font-family: Tahoma, sans-serif;
 	}
-
 </style>


### PR DESCRIPTION
Took a stab at making types for the library. I feel like it could be done better but this is what I've come up with:

1. User defines types as normal but add TS `as const` at the end:
```ts
	const customConfig = [
		{ name: 'reload', keys: ['r'] },
		{ name: 'scopeSwap', keys: ['t'] }
	] as const;
```

2. Then, they can use `as const` when calling `useKeyboardControls` and it correctly infers types:

```ts
const cfg = useKeyboardControls<typeof customConfig>();
// below is typed
const { reload, scopeSwap } = cfg;
```

https://github.com/AlexWarnes/svelte-kbc/assets/16734228/7c3a3b32-aebc-4910-bc6c-23ac6a8a205a
